### PR TITLE
사은품 가입자 이름다를 경우 문구 노출

### DIFF
--- a/public/cj.html
+++ b/public/cj.html
@@ -52,7 +52,7 @@
                 <tr>
                     <td class="tdFirst">가입자명</td>
                     <td>
-                        <input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName()"></td>
+                        <input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName();fncCheckSPOwnerName();"></td>
                 </tr>
                 <tr>
                   <td class="tdFirst">휴대폰</td>
@@ -139,7 +139,7 @@
             
     
               <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">납부자정보</p>
-                <p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);"> 위 정보와 같음 </p></div>
+                <p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);fncCheckOwnerName();"> 위 정보와 같음 </p></div>
             <table cellpadding="0" cellspacing="0">
                 <tbody>
                     <tr>
@@ -376,7 +376,7 @@
             </table>
     
             <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">사은품 (현금)
-			    </p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);"> 위 정보와 같음 </p>
+			    </p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);fncCheckSPOwnerName();"> 위 정보와 같음 </p>
             </div>
             
             <table cellpadding="0" cellspacing="0">
@@ -513,8 +513,16 @@
                     <tr height="30">
                         <td class="tdFirst">예 금 주 
                         </td><td>
-                            <input type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10"></td>
-                    </tr>
+                            <input id="g_sp_bank_holder" type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10" onblur="fncCheckSPOwnerName()"></td>
+                        </tr>
+                        <tr id="style_view_17" style="display: none;">
+                            <td colspan="2">
+                                가입자와 사은품 수령인 명의가 다를 경우, 아래의 서류를 찍어서 010-4332-3396 으로 보내주셔야 합니다. <br>
+                                1. 가입자 신분증 <br>
+                                2. 사은품 수령자 신분증 <br>
+                                3. 가족관계증명서 (가족이 아닐 경우, 위임장)
+                            </td>
+                        </tr>
             </tbody></table>
     
     

--- a/public/common.js
+++ b/public/common.js
@@ -44,6 +44,24 @@ function fncCheckOwnerName() {
 	}
 }
 
+function fncCheckSPOwnerName() {
+	var customerName = document.getElementById('c_name');
+	var spBankHolderName = document.getElementById('g_sp_bank_holder');
+
+	if(customerName.value === '') {
+		return;
+	}
+
+	if(spBankHolderName.value !== '') {
+		if(customerName.value !== spBankHolderName.value) {
+			document.getElementById("style_view_17").style.display = "table-row";
+			alert('가입자와 사은품 수령인 명의가 다를 경우, 추가 서류가 필요합니다.');
+		} else {
+			document.getElementById("style_view_17").style.display = "none";
+		}
+	}
+}
+
 // 오직 숫자만 입력 -- 스타일에 ime-mode:disabled 필요 onKeyUp
 function fncOnlyNumber(objtext1) 
 {

--- a/public/kt.html
+++ b/public/kt.html
@@ -58,7 +58,7 @@
                 <tr>
                     <td class="tdFirst">가입자명</td>
                     <td>
-                        <input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName()"></td>
+                        <input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName();fncCheckSPOwnerName();"></td>
                 </tr>
                 <tr>
                   <td class="tdFirst">휴대폰</td>
@@ -145,7 +145,7 @@
             
     
               <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">납부자정보</p>
-                <p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);"> 위 정보와 같음 </p></div>
+                <p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);fncCheckOwnerName();"> 위 정보와 같음 </p></div>
             <table cellpadding="0" cellspacing="0">
                 <tbody>
                     <tr>
@@ -350,7 +350,7 @@
                     <tr height="30" id="style_view_15" style="display: none;">
                         <td class="tdFirst">카드주 명</td>
                         <td>
-                            <input id="g_card_holder" type="text" name="g_card_holder" class="txtbox Wid30 mWid70" size="15" maxlength="15" onblur="fncCheckOwnerName(this);"></td>
+                            <input id="g_card_holder" type="text" name="g_card_holder" class="txtbox Wid30 mWid70" size="15" maxlength="15" onblur="fncCheckOwnerName();"></td>
                     </tr> 
                     <tr id="style_view_16" style="display: none;">
                         <td colspan="2">
@@ -383,7 +383,7 @@
             </table>
     
             <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">사은품 (현금)
-			    </p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);"> 위 정보와 같음 </p>
+			    </p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);fncCheckSPOwnerName();"> 위 정보와 같음 </p>
             </div>
             
             <table cellpadding="0" cellspacing="0">
@@ -520,12 +520,14 @@
                     <tr height="30">
                         <td class="tdFirst">예 금 주 
                         </td><td>
-                            <input type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10"></td>
+                            <input id="g_sp_bank_holder" type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10" onblur="fncCheckSPOwnerName()"></td>
                     </tr>
-                    <tr>
+                    <tr id="style_view_17" style="display: none;">
                         <td colspan="2">
-                            * 납부자와 사은품가 다를 경우 추가 서류가 필요합니다. <br>
-                            예금주 신분증
+                            가입자와 사은품 수령인 명의가 다를 경우, 아래의 서류를 찍어서 010-4332-3396 으로 보내주셔야 합니다. <br>
+                            1. 가입자 신분증 <br>
+                            2. 사은품 수령자 신분증 <br>
+                            3. 가족관계증명서 (가족이 아닐 경우, 위임장)
                         </td>
                     </tr>
             </tbody></table>

--- a/public/lg.html
+++ b/public/lg.html
@@ -58,7 +58,7 @@
                     <tr>
                         <td class="tdFirst">가입자명</td>
                         <td>
-                            <input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName()"></td>
+                            <input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName();fncCheckSPOwnerName();"></td>
                     </tr>
                     <tr>
                     <td class="tdFirst">휴대폰</td>
@@ -145,7 +145,7 @@
                 
         
                 <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">납부자정보</p>
-                    <p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);"> 위 정보와 같음 </p></div>
+                    <p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);fncCheckOwnerName();"> 위 정보와 같음 </p></div>
                 <table cellpadding="0" cellspacing="0">
                     <tbody>
                         <tr>
@@ -383,7 +383,7 @@
                 </table>
         
                 <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">사은품 (현금)
-			        </p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);"> 위 정보와 같음 </p>
+			        </p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);fncCheckSPOwnerName();"> 위 정보와 같음 </p>
                 </div>
                 
                 <table cellpadding="0" cellspacing="0">
@@ -521,7 +521,15 @@
                         <tr height="30">
                             <td class="tdFirst">예 금 주 
                             </td><td>
-                                <input type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10"></td>
+                            <input id="g_sp_bank_holder" type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10" onblur="fncCheckSPOwnerName()"></td>
+                        </tr>
+                        <tr id="style_view_17" style="display: none;">
+                            <td colspan="2">
+                                가입자와 사은품 수령인 명의가 다를 경우, 아래의 서류를 찍어서 010-4332-3396 으로 보내주셔야 합니다. <br>
+                                1. 가입자 신분증 <br>
+                                2. 사은품 수령자 신분증 <br>
+                                3. 가족관계증명서 (가족이 아닐 경우, 위임장)
+                            </td>
                         </tr>
                 </tbody></table>
         

--- a/public/rental.html
+++ b/public/rental.html
@@ -32,7 +32,7 @@
                     <tr>
                         <td class="tdFirst">성명</td>
                         <td>
-                            <input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName()"></td>
+                            <input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName();fncCheckSPOwnerName();"></td>
                     </tr>
                     <tr>
                     <td class="tdFirst">휴대폰</td>
@@ -77,7 +77,7 @@
                 </table>
 
                 <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">납부자정보</p>
-                    <p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);"> 위 정보와 같음 </p></div>
+                    <p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);fncCheckOwnerName();"> 위 정보와 같음 </p></div>
                 <table cellpadding="0" cellspacing="0">
                     <tbody>
                         <tr>
@@ -314,7 +314,7 @@
                 </table>
         
                 <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">사은품 (현금)
-			        </p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);"> 위 정보와 같음 </p>
+			        </p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);fncCheckSPOwnerName();"> 위 정보와 같음 </p>
                 </div>
                 
                 <table cellpadding="0" cellspacing="0">
@@ -452,7 +452,15 @@
                         <tr height="30">
                             <td class="tdFirst">예 금 주 
                             </td><td>
-                                <input type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10"></td>
+                            <input id="g_sp_bank_holder" type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10" onblur="fncCheckSPOwnerName()"></td>
+                        </tr>
+                        <tr id="style_view_17" style="display: none;">
+                            <td colspan="2">
+                                가입자와 사은품 수령인 명의가 다를 경우, 아래의 서류를 찍어서 010-4332-3396 으로 보내주셔야 합니다. <br>
+                                1. 가입자 신분증 <br>
+                                2. 사은품 수령자 신분증 <br>
+                                3. 가족관계증명서 (가족이 아닐 경우, 위임장)
+                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/public/sk.html
+++ b/public/sk.html
@@ -55,7 +55,7 @@ function fnc_tel_change(Value)
 			<tr>
 				<td class="tdFirst">가입자명</td>
 				<td>
-					<input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName()"></td>
+					<input id="c_name" type="text" name="c_name" value="" class="txtbox Wid30 mWid70" onblur="fncCheckOwnerName();fncCheckSPOwnerName();"></td>
 			</tr>
 			<tr>
 			  <td class="tdFirst">휴대폰</td>
@@ -142,7 +142,7 @@ function fnc_tel_change(Value)
         
 
       	<div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">납부자정보</p>
-        	<p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);"> 위 정보와 같음 </p></div>
+        	<p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_custom_copy('frm_regist',this);fncCheckOwnerName();"> 위 정보와 같음 </p></div>
         <table cellpadding="0" cellspacing="0">
             <tbody>
                 <tr>
@@ -380,7 +380,7 @@ function fnc_tel_change(Value)
 		</table>
 
       <div class="appliTitBox"><p class="appliTit"><img src="/images/icon_check.gif">사은품 (현금)
-			</p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);"> 위 정보와 같음 </p>
+			</p><p class="appliInfo"><input type="checkbox" name="content_copy" value="Y" class="checkbox" onclick="g_sp_bank_copy('frm_regist',this);fncCheckSPOwnerName()"> 위 정보와 같음 </p>
 		</div>
 		
         <table cellpadding="0" cellspacing="0">
@@ -518,7 +518,15 @@ function fnc_tel_change(Value)
 			<tr height="30">
 				<td class="tdFirst">예 금 주 
 				</td><td>
-					<input type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10"></td>
+					<input id="g_sp_bank_holder" type="text" name="g_sp_bank_holder" class="txtbox" value="" size="10" maxlength="10" onblur="fncCheckSPOwnerName()"></td>
+			</tr>
+			<tr id="style_view_17" style="display: none;">
+				<td colspan="2">
+					가입자와 사은품 수령인 명의가 다를 경우, 아래의 서류를 찍어서 010-4332-3396 으로 보내주셔야 합니다. <br>
+					1. 가입자 신분증 <br>
+					2. 사은품 수령자 신분증 <br>
+					3. 가족관계증명서 (가족이 아닐 경우, 위임장)
+				</td>
 			</tr>
 		</tbody></table>
 


### PR DESCRIPTION
Fix #73 

- `위 정보가 같음` 눌렀을 경우에도 유효성 검사 체크
- 사은품 수령인과 가입자 이름이 다를 경우 경고 문구 노출